### PR TITLE
Implement cross platform file info retrieval

### DIFF
--- a/pkg/filesystem/fileinfo_darwin.go
+++ b/pkg/filesystem/fileinfo_darwin.go
@@ -1,3 +1,6 @@
+//go:build darwin
+// +build darwin
+
 package filesystem
 
 import (

--- a/pkg/filesystem/fileinfo_linux.go
+++ b/pkg/filesystem/fileinfo_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+// +build linux
+
+package filesystem
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+// SystemTimes holds platform-specific time information
+type SystemTimes struct {
+	Created  time.Time
+	Accessed time.Time
+}
+
+// getSystemTimes extracts creation and access times on Linux
+func (ops *Operations) getSystemTimes(stat os.FileInfo) *SystemTimes {
+	if sys, ok := stat.Sys().(*syscall.Stat_t); ok {
+		// Linux does not provide a true creation time through Stat_t
+		// so use the change time (Ctim) as the closest approximation.
+		created := time.Unix(sys.Ctim.Sec, sys.Ctim.Nsec)
+		accessed := time.Unix(sys.Atim.Sec, sys.Atim.Nsec)
+		return &SystemTimes{Created: created, Accessed: accessed}
+	}
+	return nil
+}

--- a/pkg/filesystem/fileinfo_windows.go
+++ b/pkg/filesystem/fileinfo_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+// +build windows
+
+package filesystem
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+// SystemTimes holds platform-specific time information
+type SystemTimes struct {
+	Created  time.Time
+	Accessed time.Time
+}
+
+// getSystemTimes extracts creation and access times on Windows
+func (ops *Operations) getSystemTimes(stat os.FileInfo) *SystemTimes {
+	if sys, ok := stat.Sys().(*syscall.Win32FileAttributeData); ok {
+		created := time.Unix(0, sys.CreationTime.Nanoseconds())
+		accessed := time.Unix(0, sys.LastAccessTime.Nanoseconds())
+		return &SystemTimes{Created: created, Accessed: accessed}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add build tags to macOS implementation
- implement getSystemTimes for Linux
- implement getSystemTimes for Windows

## Testing
- `gofmt -w pkg/filesystem/fileinfo_darwin.go pkg/filesystem/fileinfo_linux.go pkg/filesystem/fileinfo_windows.go`
- `go fmt ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*