### PR TITLE
Fix buildTree recursion and add security tests

### DIFF
--- a/cmd/filesystem/main.go
+++ b/cmd/filesystem/main.go
@@ -11,6 +11,7 @@ import (
 
 	"filesystem/internal/server"
 	"filesystem/pkg/config"
+	"filesystem/pkg/security"
 )
 
 const (
@@ -131,18 +132,8 @@ func validateCommandLineDirectories(cfg *config.Config) error {
 	for i, dir := range cfg.AllowedDirectories {
 
 		// Expand home directory if needed
-		if dir == "~" || (len(dir) > 1 && dir[:2] == "~/") {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("failed to get home directory: %w", err)
-			}
-			if dir == "~" {
-				dir = homeDir
-			} else {
-				dir = homeDir + dir[1:]
-			}
-			cfg.AllowedDirectories[i] = dir
-		}
+		dir = security.ExpandHomePath(dir)
+		cfg.AllowedDirectories[i] = dir
 
 		// Check if directory exists and is accessible
 		info, err := os.Stat(dir)

--- a/internal/handlers/tools_test.go
+++ b/internal/handlers/tools_test.go
@@ -22,7 +22,7 @@ func newTestHandlers(t *testing.T) (*ToolHandlers, string) {
 	base := t.TempDir()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	pv := security.NewPathValidator([]string{base}, logger)
-	ops := filesystem.NewOperations(logger)
+	ops := filesystem.NewOperations(pv, logger)
 	return NewToolHandlers(pv, ops, logger), base
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
+
+	"filesystem/pkg/security"
 )
 
 // Config holds the application configuration
@@ -111,17 +113,7 @@ func normalizeDirectories(cfg *Config) error {
 	for _, dir := range cfg.AllowedDirectories {
 
 		// Expand home directory if needed
-		if dir == "~" || len(dir) > 1 && dir[:2] == "~/" {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("failed to get home directory: %w", err)
-			}
-			if dir == "~" {
-				dir = homeDir
-			} else {
-				dir = filepath.Join(homeDir, dir[2:])
-			}
-		}
+		dir = security.ExpandHomePath(dir)
 
 		// Convert to absolute path
 		absDir, err := filepath.Abs(dir)

--- a/pkg/filesystem/operations.go
+++ b/pkg/filesystem/operations.go
@@ -383,7 +383,7 @@ func (ops *Operations) buildTree(dirPath string, visited map[string]bool) ([]Tre
 				// Skip this directory if validation fails
 				continue
 			}
-			children, err := ops.buildTree(validPath)
+			children, err := ops.buildTree(validPath, visited)
 			if err != nil {
 				ops.logger.Warn("Failed to build subtree", "path", subPath, "error", err)
 				// Continue with empty children rather than failing

--- a/pkg/filesystem/operations_test.go
+++ b/pkg/filesystem/operations_test.go
@@ -1,0 +1,67 @@
+package filesystem
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"filesystem/pkg/security"
+)
+
+func newOps(t *testing.T) (*Operations, string) {
+	t.Helper()
+	base := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	pv := security.NewPathValidator([]string{base}, logger)
+	ops := NewOperations(pv, logger)
+	return ops, base
+}
+
+type treeEntry struct {
+	Name     string      `json:"name"`
+	Type     string      `json:"type"`
+	Children []treeEntry `json:"children,omitempty"`
+}
+
+func TestDirectoryTreeSimple(t *testing.T) {
+	ops, base := newOps(t)
+	sub := filepath.Join(base, "sub")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	file := filepath.Join(sub, "a.txt")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	jsonStr, err := ops.DirectoryTree(base)
+	if err != nil {
+		t.Fatalf("tree error: %v", err)
+	}
+	var entries []treeEntry
+	if err := json.Unmarshal([]byte(jsonStr), &entries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("no entries returned")
+	}
+}
+
+func TestDirectoryTreeSymlinkLoop(t *testing.T) {
+	ops, base := newOps(t)
+	sub := filepath.Join(base, "sub")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// create symlink to parent to form loop
+	link := filepath.Join(sub, "loop")
+	if err := os.Symlink(base, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := ops.DirectoryTree(base); err != nil {
+		t.Fatalf("tree with symlink failed: %v", err)
+	}
+}

--- a/pkg/security/homedir.go
+++ b/pkg/security/homedir.go
@@ -1,0 +1,20 @@
+package security
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ExpandHomePath expands ~ and ~/ in file paths.
+func ExpandHomePath(path string) string {
+	if path == "~" {
+		if homeDir, err := os.UserHomeDir(); err == nil {
+			return homeDir
+		}
+	} else if len(path) > 1 && path[:2] == "~/" {
+		if homeDir, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(homeDir, path[2:])
+		}
+	}
+	return path
+}

--- a/pkg/security/path.go
+++ b/pkg/security/path.go
@@ -41,7 +41,7 @@ func (pv *PathValidator) ValidatePath(requestedPath string) (string, error) {
 	}
 
 	// Expand home directory if needed
-	expandedPath := pv.expandHomePath(requestedPath)
+	expandedPath := ExpandHomePath(requestedPath)
 
 	// Convert to absolute path
 	var absolutePath string
@@ -80,16 +80,7 @@ func (pv *PathValidator) ValidatePath(requestedPath string) (string, error) {
 
 // expandHomePath expands ~ and ~/ in file paths
 func (pv *PathValidator) expandHomePath(path string) string {
-	if path == "~" {
-		if homeDir, err := os.UserHomeDir(); err == nil {
-			return homeDir
-		}
-	} else if len(path) > 1 && path[:2] == "~/" {
-		if homeDir, err := os.UserHomeDir(); err == nil {
-			return filepath.Join(homeDir, path[2:])
-		}
-	}
-	return path
+	return ExpandHomePath(path)
 }
 
 // isPathAllowed checks if a path is within any allowed directory

--- a/pkg/security/path_test.go
+++ b/pkg/security/path_test.go
@@ -1,0 +1,101 @@
+package security
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newValidator(t *testing.T) (*PathValidator, string) {
+	t.Helper()
+	base := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	pv := NewPathValidator([]string{base}, logger)
+	return pv, base
+}
+
+func TestValidatePathWithinAllowed(t *testing.T) {
+	pv, base := newValidator(t)
+	file := filepath.Join(base, "file.txt")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatalf("prep file: %v", err)
+	}
+
+	p, err := pv.ValidatePath(file)
+	if err != nil {
+		t.Fatalf("validate error: %v", err)
+	}
+	if p != file {
+		t.Fatalf("unexpected path: %s", p)
+	}
+}
+
+func TestValidatePathOutsideAllowed(t *testing.T) {
+	pv, _ := newValidator(t)
+	outside := filepath.Join(os.TempDir(), "outside.txt")
+	if _, err := pv.ValidatePath(outside); err == nil {
+		t.Fatalf("expected error for outside path")
+	}
+}
+
+func TestValidateSymlinkTarget(t *testing.T) {
+	pv, base := newValidator(t)
+	target := filepath.Join(base, "target.txt")
+	if err := os.WriteFile(target, []byte("x"), 0644); err != nil {
+		t.Fatalf("prep target: %v", err)
+	}
+	link := filepath.Join(base, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	p, err := pv.ValidatePath(link)
+	if err != nil {
+		t.Fatalf("validate symlink: %v", err)
+	}
+	if p != target {
+		t.Fatalf("expected real path %s got %s", target, p)
+	}
+}
+
+func TestValidateSymlinkOutside(t *testing.T) {
+	pv, base := newValidator(t)
+	outsideDir := t.TempDir()
+	target := filepath.Join(outsideDir, "target.txt")
+	if err := os.WriteFile(target, []byte("x"), 0644); err != nil {
+		t.Fatalf("prep target: %v", err)
+	}
+	link := filepath.Join(base, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := pv.ValidatePath(link); err == nil {
+		t.Fatalf("expected error for outside symlink")
+	}
+}
+
+func TestExpandHomePath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	if got := ExpandHomePath("~"); got != home {
+		t.Fatalf("expected %s got %s", home, got)
+	}
+	sub := ExpandHomePath("~/sub")
+	if sub != filepath.Join(home, "sub") {
+		t.Fatalf("expected joined path")
+	}
+}
+
+func TestGetAllowedDirectories(t *testing.T) {
+	pv, base := newValidator(t)
+	dirs := pv.GetAllowedDirectories()
+	if len(dirs) != 1 || dirs[0] != base {
+		t.Fatalf("unexpected dirs: %v", dirs)
+	}
+	// ensure modification doesn't affect internal slice
+	dirs[0] = "changed"
+	if pv.allowedDirectories[0] != base {
+		t.Fatalf("internal slice modified")
+	}
+}


### PR DESCRIPTION
## Summary
- fix missing argument in buildTree recursion
- use shared ExpandHomePath helper across config and CLI
- ensure test helpers create Operations correctly
- add ExpandHomePath helper and PathValidator tests
- test DirectoryTree recursion

## Testing
- `go test ./...` *(fails: proxyconnect tcp: no route to host)*