### PR TITLE
Remove unused expandHomePath method

### DIFF
--- a/pkg/security/path.go
+++ b/pkg/security/path.go
@@ -78,10 +78,6 @@ func (pv *PathValidator) ValidatePath(requestedPath string) (string, error) {
 	return realPath, nil
 }
 
-// expandHomePath expands ~ and ~/ in file paths
-func (pv *PathValidator) expandHomePath(path string) string {
-	return ExpandHomePath(path)
-}
 
 // isPathAllowed checks if a path is within any allowed directory
 func (pv *PathValidator) isPathAllowed(absolutePath string) bool {


### PR DESCRIPTION
## Summary
- remove unused `expandHomePath` helper
- paths are expanded using `ExpandHomePath`

## Testing
- `go vet ./...` *(fails: no route to host)*
- `go build ./...` *(fails: no route to host)*