### PR TITLE
Check destination path before rename

### DIFF
--- a/internal/handlers/tools_test.go
+++ b/internal/handlers/tools_test.go
@@ -132,6 +132,33 @@ func TestHandleMoveAndSearchFile(t *testing.T) {
 	}
 }
 
+func TestHandleMoveFileDestinationExists(t *testing.T) {
+	th, base := newTestHandlers(t)
+	ctx := context.Background()
+	src := filepath.Join(base, "src2.txt")
+	if err := os.WriteFile(src, []byte("z"), 0644); err != nil {
+		t.Fatalf("prep src: %v", err)
+	}
+	dst := filepath.Join(base, "dst2.txt")
+	if err := os.WriteFile(dst, []byte("existing"), 0644); err != nil {
+		t.Fatalf("prep dst: %v", err)
+	}
+
+	moveReq := newRequest(map[string]interface{}{"source": src, "destination": dst})
+	if _, err := th.handleMoveFile(ctx, moveReq); err == nil {
+		t.Fatalf("expected error for existing destination")
+	}
+
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("source missing after failed move: %v", err)
+	}
+
+	data, err := os.ReadFile(dst)
+	if err != nil || string(data) != "existing" {
+		t.Fatalf("destination modified: %s %v", string(data), err)
+	}
+}
+
 func TestHandleGetFileInfo(t *testing.T) {
 	th, base := newTestHandlers(t)
 	ctx := context.Background()

--- a/pkg/filesystem/operations.go
+++ b/pkg/filesystem/operations.go
@@ -410,6 +410,15 @@ func (ops *Operations) MoveFile(sourcePath, destPath string) error {
 
 	ops.logger.Debug("Moving file", "source", sourcePath, "destination", destPath)
 
+	// Check if destination already exists to avoid overwriting
+	if _, err := os.Stat(destPath); err == nil {
+		ops.logger.Warn("Destination already exists", "path", destPath)
+		return fmt.Errorf("destination already exists")
+	} else if !os.IsNotExist(err) {
+		ops.logger.Error("Failed to check destination", "path", destPath, "error", err)
+		return fmt.Errorf("failed to check destination: %w", err)
+	}
+
 	err := os.Rename(sourcePath, destPath)
 	if err != nil {
 		ops.logger.Error("Failed to move file", "source", sourcePath, "destination", destPath, "error", err)


### PR DESCRIPTION
## Summary
- prevent overwriting when moving files by checking destination path
- test move_file failure when destination exists

## Testing
- `go test ./...` *(fails: no network access)*