### PR TITLE
Skip invalid paths when reading multiple files

### DIFF
--- a/internal/handlers/tools.go
+++ b/internal/handlers/tools.go
@@ -219,17 +219,17 @@ func (th *ToolHandlers) handleReadMultipleFiles(ctx context.Context, req mcp.Cal
 	if errRes != nil {
 		return errRes, nil
 	}
-	// Validate each path
+	// Validate each path and only keep valid ones
 	paths := make([]string, 0, len(pathsSlice))
 	for i := 0; i < len(pathsSlice) && i < 100; i++ {
 		path := pathsSlice[i]
 		validPath, err := th.pathValidator.ValidatePath(path)
 		if err != nil {
+			// Skip invalid paths but log the failure
 			th.logger.Warn("Path validation failed", "path", path, "error", err)
-			paths = append(paths, path)
-		} else {
-			paths = append(paths, validPath)
+			continue
 		}
+		paths = append(paths, validPath)
 	}
 
 	if len(paths) == 0 {

--- a/internal/handlers/tools_test.go
+++ b/internal/handlers/tools_test.go
@@ -163,3 +163,35 @@ func TestHandleInvalidPath(t *testing.T) {
 		t.Fatalf("expected error for invalid path")
 	}
 }
+
+func TestHandleReadMultipleFilesInvalid(t *testing.T) {
+	th, base := newTestHandlers(t)
+	ctx := context.Background()
+
+	valid := filepath.Join(base, "a.txt")
+	if err := os.WriteFile(valid, []byte("data"), 0644); err != nil {
+		t.Fatalf("prep valid: %v", err)
+	}
+
+	invalid := filepath.Join(os.TempDir(), "outside.txt")
+
+	req := newRequest(map[string]interface{}{"paths": []interface{}{valid, invalid}})
+	res, err := th.handleReadMultipleFiles(ctx, req)
+	if err != nil {
+		t.Fatalf("mixed read error: %v", err)
+	}
+	b, _ := json.Marshal(res)
+	if strings.Contains(string(b), invalid) {
+		t.Fatalf("response should not include invalid path")
+	}
+
+	badReq := newRequest(map[string]interface{}{"paths": []interface{}{invalid}})
+	badRes, err := th.handleReadMultipleFiles(ctx, badReq)
+	if err != nil {
+		t.Fatalf("invalid read error: %v", err)
+	}
+	bb, _ := json.Marshal(badRes)
+	if !strings.Contains(string(bb), "No valid paths") {
+		t.Fatalf("expected no valid paths error")
+	}
+}


### PR DESCRIPTION
## Summary
- validate each path in `handleReadMultipleFiles` and only pass valid ones
- add tests for mixed and invalid file lists

## Testing
- `go test ./...` *(fails: cannot download modules)*