### PR TITLE
Normalize CLI dirs to absolute path

### DIFF
--- a/cmd/filesystem/main.go
+++ b/cmd/filesystem/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"filesystem/internal/server"
@@ -133,7 +134,15 @@ func validateCommandLineDirectories(cfg *config.Config) error {
 
 		// Expand home directory if needed
 		dir = security.ExpandHomePath(dir)
-		cfg.AllowedDirectories[i] = dir
+
+		// Convert to absolute path
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			return fmt.Errorf("failed to get absolute path for %s: %w", dir, err)
+		}
+
+		cfg.AllowedDirectories[i] = absDir
+		dir = absDir
 
 		// Check if directory exists and is accessible
 		info, err := os.Stat(dir)

--- a/cmd/filesystem/main_test.go
+++ b/cmd/filesystem/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"filesystem/pkg/config"
+)
+
+func TestValidateCommandLineDirectoriesDot(t *testing.T) {
+	tmp := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cwd: %v", err)
+	}
+	// change to temporary directory for the test
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(wd) })
+
+	cfg := config.Default()
+	cfg.AllowedDirectories = []string{"."}
+
+	if err := validateCommandLineDirectories(cfg); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	expect, _ := filepath.Abs(".")
+	if len(cfg.AllowedDirectories) != 1 || cfg.AllowedDirectories[0] != expect {
+		t.Fatalf("expected %s got %v", expect, cfg.AllowedDirectories)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure command line directories are expanded and converted to absolute paths
- test validating `.` passed on the command line

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*