### PR TITLE
Use filepath.Rel for path check and add tests

### DIFF
--- a/pkg/security/path.go
+++ b/pkg/security/path.go
@@ -78,7 +78,6 @@ func (pv *PathValidator) ValidatePath(requestedPath string) (string, error) {
 	return realPath, nil
 }
 
-
 // isPathAllowed checks if a path is within any allowed directory
 func (pv *PathValidator) isPathAllowed(absolutePath string) bool {
 	normalizedPath := filepath.Clean(absolutePath)
@@ -97,15 +96,11 @@ func (pv *PathValidator) isPathAllowed(absolutePath string) bool {
 
 // isPathUnderDirectory checks if a path is under a given directory
 func (pv *PathValidator) isPathUnderDirectory(path, dir string) bool {
-	// Ensure both paths end with separator for proper comparison
-	if !strings.HasSuffix(dir, string(filepath.Separator)) {
-		dir += string(filepath.Separator)
+	rel, err := filepath.Rel(dir, path)
+	if err == nil && !strings.HasPrefix(rel, "..") {
+		return true
 	}
-	if !strings.HasSuffix(path, string(filepath.Separator)) {
-		path += string(filepath.Separator)
-	}
-
-	return strings.HasPrefix(path, dir)
+	return false
 }
 
 // validateRealPath handles symlinks and validates the real path

--- a/pkg/security/path_test.go
+++ b/pkg/security/path_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -97,5 +98,31 @@ func TestGetAllowedDirectories(t *testing.T) {
 	dirs[0] = "changed"
 	if pv.allowedDirectories[0] != base {
 		t.Fatalf("internal slice modified")
+	}
+}
+
+func TestIsPathUnderDirectoryRelativeUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-specific test")
+	}
+	pv := &PathValidator{}
+	if !pv.isPathUnderDirectory("a/b/c", "a/b") {
+		t.Fatalf("expected true for relative unix path")
+	}
+	if pv.isPathUnderDirectory("../outside", "a/b") {
+		t.Fatalf("expected false for path outside")
+	}
+}
+
+func TestIsPathUnderDirectoryRelativeWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-specific test")
+	}
+	pv := &PathValidator{}
+	if !pv.isPathUnderDirectory(`a\b\c`, `a\b`) {
+		t.Fatalf("expected true for windows path")
+	}
+	if pv.isPathUnderDirectory(`..\outside`, `a\b`) {
+		t.Fatalf("expected false for outside path")
 	}
 }


### PR DESCRIPTION
## Summary
- use `filepath.Rel` instead of string prefix for checking if a path is under a directory
- add tests for Unix and Windows relative path cases

## Testing
- `go test ./...` *(fails: proxy connect tcp: no route to host)*