### PR TITLE
Remove unused startup retry constant

### DIFF
--- a/cmd/filesystem/main.go
+++ b/cmd/filesystem/main.go
@@ -16,9 +16,6 @@ import (
 )
 
 const (
-	// maxStartupRetries limits startup retry attempts per Rule 2 (fixed loop bounds)
-	maxStartupRetries = 3
-
 	// exitCodeSuccess indicates successful termination
 	exitCodeSuccess = 0
 


### PR DESCRIPTION
## Summary
- remove `maxStartupRetries` constant from the filesystem CLI

## Testing
- `go test ./...` *(fails: no route to host)*