### PR TITLE
Add extra validation tests

### DIFF
--- a/cmd/filesystem/main_test.go
+++ b/cmd/filesystem/main_test.go
@@ -32,3 +32,39 @@ func TestValidateCommandLineDirectoriesDot(t *testing.T) {
 		t.Fatalf("expected %s got %v", expect, cfg.AllowedDirectories)
 	}
 }
+
+func TestValidateCommandLineDirectoriesNonexistent(t *testing.T) {
+	base := t.TempDir()
+	missing := filepath.Join(base, "no_such")
+
+	cfg := config.Default()
+	cfg.AllowedDirectories = []string{missing}
+
+	if err := validateCommandLineDirectories(cfg); err == nil {
+		t.Fatalf("expected error for nonexistent directory")
+	}
+}
+
+func TestValidateCommandLineDirectoriesFile(t *testing.T) {
+	base := t.TempDir()
+	file := filepath.Join(base, "file.txt")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.AllowedDirectories = []string{file}
+
+	if err := validateCommandLineDirectories(cfg); err == nil {
+		t.Fatalf("expected error for non-directory path")
+	}
+}
+
+func TestValidateCommandLineDirectoriesEmpty(t *testing.T) {
+	cfg := config.Default()
+	cfg.AllowedDirectories = []string{}
+
+	if err := validateCommandLineDirectories(cfg); err == nil {
+		t.Fatalf("expected error for empty slice")
+	}
+}


### PR DESCRIPTION
## Summary
- test non-existent and non-directory paths for CLI directory validation
- ensure empty slice results in an error

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*