### PR TITLE
Add write size limit and tests

### DIFF
--- a/pkg/filesystem/operations.go
+++ b/pkg/filesystem/operations.go
@@ -20,7 +20,8 @@ import (
 	"filesystem/pkg/security"
 )
 
-const maxReadSize int64 = 1 * 1024 * 1024 // 1MB
+const maxReadSize int64 = 1 * 1024 * 1024  // 1MB
+const maxWriteSize int64 = 1 * 1024 * 1024 // 1MB
 
 // maxTreeDepth defines the maximum depth DirectoryTree will recurse
 const maxTreeDepth int = 20
@@ -125,6 +126,11 @@ func (ops *Operations) WriteFile(filePath, content string) error {
 	// Input validation per Rule 7
 	if filePath == "" {
 		return fmt.Errorf("file path cannot be empty")
+	}
+
+	if int64(len(content)) > maxWriteSize {
+		ops.logger.Warn("Content size exceeds limit", "path", filePath, "size", len(content))
+		return fmt.Errorf("content exceeds maximum allowed size")
 	}
 
 	ops.logger.Debug("Writing file", "path", filePath, "size", len(content))

--- a/pkg/filesystem/operations_test.go
+++ b/pkg/filesystem/operations_test.go
@@ -128,6 +128,39 @@ func TestReadFileExceedsLimit(t *testing.T) {
 	}
 }
 
+func TestWriteFileWithinLimit(t *testing.T) {
+	ops, base := newOps(t)
+	p := filepath.Join(base, "out.txt")
+	content := bytes.Repeat([]byte("c"), int(maxWriteSize))
+
+	if err := ops.WriteFile(p, string(content)); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(data, content) {
+		t.Fatalf("content mismatch")
+	}
+}
+
+func TestWriteFileExceedsLimit(t *testing.T) {
+	ops, base := newOps(t)
+	p := filepath.Join(base, "too_big.txt")
+	content := bytes.Repeat([]byte("d"), int(maxWriteSize)+1)
+
+	if err := ops.WriteFile(p, string(content)); err == nil {
+		t.Fatalf("expected error for oversized content")
+	}
+	if _, err := os.Stat(p); err == nil {
+		t.Fatalf("file should not have been created")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected stat error: %v", err)
+	}
+}
+
 func TestSearchFilesExcludePatterns(t *testing.T) {
 	ops, base := newOps(t)
 


### PR DESCRIPTION
## Summary
- limit `WriteFile` using a new `maxWriteSize` constant
- test oversized writes and allow only files <= limit

## Testing
- `go test ./...` *(fails: no network access)*