### PR TITLE
Fix YAML indentation for golangci-lint and gosec steps

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,15 +22,15 @@ jobs:
         go-version: '1.24.2'
         cache: true
 
-      - name: Install golangci-lint
-        run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+    - name: Install golangci-lint
+      run: |
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-      - name: Install gosec
-        run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+    - name: Install gosec
+      run: |
+        go install github.com/securego/gosec/v2/cmd/gosec@latest
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
## Summary
- fix indentation for golangci-lint and gosec installation steps in go.yml

## Testing
- `yamllint .github/workflows/go.yml` *(fails: command not found)*
- `act -n -j build` *(fails: command not found)*